### PR TITLE
Feat/infra monitoring

### DIFF
--- a/coupon/coupon-api/build.gradle
+++ b/coupon/coupon-api/build.gradle
@@ -4,6 +4,7 @@ jar.enabled = false
 dependencies {
     implementation project(":coupon:coupon-enum")
     implementation project(":support:logging")
+    implementation project(":support:monitoring")
 
     // spring boot
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/coupon/coupon-api/build.gradle
+++ b/coupon/coupon-api/build.gradle
@@ -12,8 +12,9 @@ dependencies {
     // spring data jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    // h2
+    // h2, mysql
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // test
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/coupon/coupon-api/src/main/resources/application-local.yml
+++ b/coupon/coupon-api/src/main/resources/application-local.yml
@@ -1,23 +1,15 @@
 spring:
   datasource:
-    url: 'jdbc:h2:mem:core;MODE=MYSQL;'
-    username: 'user'
-    password: ''
-    driver-class-name: org.h2.Driver
+    url: jdbc:mysql://localhost:3306/coupon
+    username: root
+    password: 1234
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
         show_sql: true
-  sql:
-    init:
-      mode: never
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
 
 springdoc:
   swagger-ui:

--- a/coupon/coupon-api/src/main/resources/application.yml
+++ b/coupon/coupon-api/src/main/resources/application.yml
@@ -4,10 +4,17 @@ spring.profiles.active: local
 spring:
   config:
     import:
-#      - monitoring.yml
+      - monitoring.yml
       - logging.yml
 #      - db-core.yml
   web.resources.add-mappings: false
+
+server:
+  tomcat:
+    max-connections: 20000
+    threads:
+      max: 600
+      min-spare: 100
 
 ---
 spring.config.activate.on-profile: local

--- a/coupon/mysql/initdb.d/create_schema.sql
+++ b/coupon/mysql/initdb.d/create_schema.sql
@@ -1,0 +1,1 @@
+create database coupon;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.8"
+services:
+  mysql:
+    container_name: mysql
+    image: mysql:8.0.34
+    restart: always
+    ports:
+      - '3306:3306'
+    environment:
+      - MYSQL_ROOT_PASSWORD=1234
+    volumes:
+      - ./coupon/mysql/initdb.d:/docker-entrypoint-initdb.d
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./support/monitoring/infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./support/monitoring/infra/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./support/monitoring/infra/grafana/datasources:/etc/grafana/provisioning/datasources
+
+  influxdb:
+    image: influxdb:1.8
+    container_name: influx
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=admin1234

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,3 +11,5 @@ rootProject.name = 'springboot-coupon-system'
 include("coupon:coupon-api")
 include("coupon:coupon-enum")
 include("support:logging")
+include 'support:monitoring'
+

--- a/support/monitoring/build.gradle
+++ b/support/monitoring/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+}

--- a/support/monitoring/infra/grafana/dashboards/dashboard.yml
+++ b/support/monitoring/infra/grafana/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/support/monitoring/infra/grafana/datasources/datasource.yml
+++ b/support/monitoring/infra/grafana/datasources/datasource.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: prometheus
+
+datasources:
+  - name: coupon-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+  - name: coupon-performance-influxdb
+    type: influxdb
+    access: proxy
+    database: k6
+    user: admin
+    password: admin1234
+    url: http://influxdb:8086

--- a/support/monitoring/infra/k6/coupon-health.js
+++ b/support/monitoring/infra/k6/coupon-health.js
@@ -1,0 +1,19 @@
+import http from 'k6/http';
+import {sleep} from 'k6';
+
+export const options = {
+    vus: 10,
+    summaryTimeUnit: 's',
+    duration: '600s',
+};
+
+export default function () {
+    const url = 'http://localhost:8080/api/health';
+
+    http.get(url, {
+        tags: {name: 'HealthCheck'},
+        timeout: '30s',
+        noConnectionReuse: true,
+    });
+    sleep(1);
+}

--- a/support/monitoring/infra/prometheus/prometheus.yml
+++ b/support/monitoring/infra/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'coupon-server'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: [ 'host.docker.internal:8080' ]

--- a/support/monitoring/src/main/resources/monitoring.yml
+++ b/support/monitoring/src/main/resources/monitoring.yml
@@ -1,0 +1,5 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 주요 작업 내용

- [x] add monitoring module
- [x] change db from h2 to mysql
- [x] write docker-compose for monitoring


---

## 사전 준비 및 실행

> MAC OS 환경 기준

먼저, Docker desktop이 설치되어야 한다.

그런 다음, `docker-compose.yml` 파일이 있는 경로로 이동한 뒤, 아래와 같이 명령어 입력한다.
- 명령어: docker-compose up -d

해당 명령어를 통해 아래와 같이 4개의 도커 컨테이너가 실행되어야 한다.

<img width="1097" alt="docker_desktop" src="https://github.com/user-attachments/assets/788c7785-bcc2-45d0-b4f2-42436215db3c" />

마지막으로 `core-api` 모듈에 있는 CouponApplication 을 실행하면 정상 동작하는 것을 확인할 수 있다.



