### PR TITLE
feat(coupon-enum): add UserRole enum and prevent external exposure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 
-- [ ] 💯 테스트는 통과했나?
-- [ ] ✅ 빌드는 성공했나?
-- [ ] 🧹 불필요한 코드는 제거했나?
-- [ ] 💭 이슈는 등록했는가?
-- [ ] 🔖 라벨은 등록했나? ex. `feature`, `refactor`
+- [ ] 💯 Have you passed all tests?
+- [ ] ✅ Does the project build successfully?
+- [ ] 🧹 Have you removed unnecessary code?
+- [ ] 💭 Is the related issue registered?
+- [ ] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`
 
-## 작업 내용
+## Description
 
 - [ ]
 
-## 주의사항
+## Considerations
 
-- Closes #{이슈 번호}
+- Closes #{issue number}

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/application/dto/UserSignUpResult.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/application/dto/UserSignUpResult.java
@@ -4,8 +4,8 @@ import dev.be.coupon.api.user.domain.User;
 
 import java.util.UUID;
 
-public record UserSignUpResult(UUID id, String username) {
+public record UserSignUpResult(UUID id, String username, String role) {
     public static UserSignUpResult from(final User user) {
-        return new UserSignUpResult(user.getId(), user.getUsername());
+        return new UserSignUpResult(user.getId(), user.getUsername(), user.getUserRole().name().toLowerCase());
     }
 }

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/domain/User.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/domain/User.java
@@ -1,10 +1,13 @@
 package dev.be.coupon.api.user.domain;
 
+import deb.be.coupon.UserRole;
 import dev.be.coupon.api.user.domain.vo.Password;
 import dev.be.coupon.api.user.domain.vo.Username;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
@@ -19,6 +22,10 @@ public class User {
     @Id
     private UUID id;
 
+    @Column(name = "user_role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+
     @Embedded
     private Username username;
 
@@ -29,6 +36,7 @@ public class User {
     }
 
     public User(final String username, final String password) {
+        this.userRole = UserRole.USER;
         this.id = UUID.randomUUID();
         this.username = new Username(username);
         this.password = new Password(password);
@@ -48,6 +56,10 @@ public class User {
 
     public UUID getId() {
         return id;
+    }
+
+    public UserRole getUserRole() {
+        return userRole;
     }
 
     public String getUsername() {

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/ui/UserController.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/ui/UserController.java
@@ -29,7 +29,7 @@ public class UserController implements UserControllerDocs {
     public ResponseEntity<CommonResponse<UserSignUpResponse>> signUp(@Valid @RequestBody final UserSignUpRequest request) {
         UserSignUpCommand command = new UserSignUpCommand(request.username(), request.password());
         UserSignUpResult result = userService.signUp(command);
-        UserSignUpResponse response = new UserSignUpResponse(result.id(), result.username());
+        UserSignUpResponse response = new UserSignUpResponse(result.id(), result.username(), result.role());
 
         return ResponseEntity.created(URI.create("/api/users/" + response.id()))
                 .body(CommonResponse.success(response));

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/ui/dto/UserSignUpResponse.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/user/ui/dto/UserSignUpResponse.java
@@ -2,5 +2,5 @@ package dev.be.coupon.api.user.ui.dto;
 
 import java.util.UUID;
 
-public record UserSignUpResponse (UUID id, String username) {
+public record UserSignUpResponse (UUID id, String username, String role) {
 }

--- a/coupon/coupon-enum/build.gradle
+++ b/coupon/coupon-enum/build.gradle
@@ -1,0 +1,12 @@
+/**
+ * coupon-enum 모듈
+ *
+ * 역할:
+ * - 도메인에서 공통으로 사용하는 Enum 타입을 정의합니다.
+ * - 예: UserRole, CouponType, OrderStatus 등.
+ *
+ * 주의사항:
+ * - enum 은 내부 도메인 로직에서만 사용되며, 외부 API 응답에서 직접 노출하지 않습니다.
+ * - 외부 노출이 필요한 경우, enum.name() 등을 사용하여 String 으로 변환 후 전달합니다.
+ * - core-api 모듈에서는 core-enum 을 의존하지만, enum 타입 자체를 DTO 에 포함시키지 않도록 합니다.
+ */

--- a/coupon/coupon-enum/src/main/java/deb/be/coupon/UserRole.java
+++ b/coupon/coupon-enum/src/main/java/deb/be/coupon/UserRole.java
@@ -1,4 +1,15 @@
 package deb.be.coupon;
+
+/**
+ * 사용자 권한을 정의하는 Enum.
+ * - USER: 일반 사용자
+ * - ADMIN: 관리자
+ *
+ * [주의]
+ * 이 Enum 은 API 계층에 직접 노출되지 않으며,
+ * 외부 노출 시에는 반드시 String 형태로 변환해 사용해야 합니다.
+ * 예: userRole.name().toLowerCase()
+ */
 public enum UserRole {
     USER, ADMIN
 }

--- a/coupon/coupon-enum/src/main/java/deb/be/coupon/UserRole.java
+++ b/coupon/coupon-enum/src/main/java/deb/be/coupon/UserRole.java
@@ -1,0 +1,4 @@
+package deb.be.coupon;
+public enum UserRole {
+    USER, ADMIN
+}


### PR DESCRIPTION
- [x] 💯 Have you passed all tests?
- [x] ✅ Does the project build successfully?
- [x] 🧹 Have you removed unnecessary code?
- [x] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`

## Description

- [x] added `UserRole` enum(USER, ADMIN)
  - converted `UserRole` to `String` when exposing via API to avoid leaking internal enums
  - added `role: String` filed to `UserSignupResult` and `UserSignUpResponse`
- [x] added comment in `core-enum` to clarify usage and exposure policy
- [x] update PR template from Korean to English

## Considerations

- Enums are intended for internal domain use only
- API responses expose role information as a `String` to maintain module separation and avoid direct dependency on enums
