### PR TITLE
refactor: [coupon-api] replace RDB-based issuance logic with Redis-based flow

### DIFF
--- a/coupon/coupon-api/build.gradle
+++ b/coupon/coupon-api/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
 
+    // jackson
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 
 tasks.withType(Test).configureEach {

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/CouponService.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/CouponService.java
@@ -9,12 +9,18 @@ import dev.be.coupon.api.coupon.application.exception.CouponNotFoundException;
 import dev.be.coupon.api.coupon.application.exception.InvalidIssuedCouponException;
 import dev.be.coupon.api.coupon.domain.Coupon;
 import dev.be.coupon.api.coupon.domain.CouponRepository;
+import dev.be.coupon.api.coupon.domain.FailedIssuedCoupon;
+import dev.be.coupon.api.coupon.domain.FailedIssuedCouponRepository;
 import dev.be.coupon.api.coupon.domain.IssuedCouponRepository;
 import dev.be.coupon.api.coupon.domain.UserRoleChecker;
 import dev.be.coupon.api.coupon.domain.exception.InvalidCouponException;
 import dev.be.coupon.api.coupon.domain.exception.UnauthorizedAccessException;
-import dev.be.coupon.api.coupon.infrastructure.CouponCountRedisRepository;
 import dev.be.coupon.api.coupon.infrastructure.kafka.producer.CouponIssueProducer;
+import dev.be.coupon.api.coupon.infrastructure.redis.AppliedUserRepository;
+import dev.be.coupon.api.coupon.infrastructure.redis.CouponCacheRepository;
+import dev.be.coupon.api.coupon.infrastructure.redis.CouponCountRedisRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,21 +31,32 @@ import java.util.UUID;
 public class CouponService {
 
     private final CouponRepository couponRepository;
-    private final UserRoleChecker userRoleChecker;
-    private final IssuedCouponRepository issuedCouponRepository;
+    private final CouponCacheRepository couponCacheRepository;
     private final CouponCountRedisRepository couponCountRedisRepository;
     private final CouponIssueProducer couponIssueProducer;
+    private final IssuedCouponRepository issuedCouponRepository;
+    private final AppliedUserRepository appliedUserRepository;
+    private final FailedIssuedCouponRepository failedIssuedCouponRepository;
+    private final UserRoleChecker userRoleChecker;
+
+    private final Logger log = LoggerFactory.getLogger(CouponService.class);
 
     public CouponService(final CouponRepository couponRepository,
-                         final UserRoleChecker userRoleChecker,
-                         final IssuedCouponRepository issuedCouponRepository,
+                         final CouponCacheRepository couponCacheRepository,
                          final CouponCountRedisRepository couponCountRedisRepository,
-                         final CouponIssueProducer couponIssueProducer) {
+                         final CouponIssueProducer couponIssueProducer,
+                         final IssuedCouponRepository issuedCouponRepository,
+                         final AppliedUserRepository appliedUserRepository,
+                         final FailedIssuedCouponRepository failedIssuedCouponRepository,
+                         final UserRoleChecker userRoleChecker) {
         this.couponRepository = couponRepository;
-        this.userRoleChecker = userRoleChecker;
-        this.issuedCouponRepository = issuedCouponRepository;
+        this.couponCacheRepository = couponCacheRepository;
         this.couponCountRedisRepository = couponCountRedisRepository;
         this.couponIssueProducer = couponIssueProducer;
+        this.issuedCouponRepository = issuedCouponRepository;
+        this.appliedUserRepository = appliedUserRepository;
+        this.failedIssuedCouponRepository = failedIssuedCouponRepository;
+        this.userRoleChecker = userRoleChecker;
     }
 
     public CouponCreateResult create(
@@ -55,10 +72,20 @@ public class CouponService {
 
     /**
      * 쿠폰 발급 시 핵심 검증 포인트
-     * 1. 전체 발급 수량 제한 - Redis INCR 기반 제어 (coupon_count:{couponId})
-     * 2. 사용자별 중복 발급 방지 - Redis 락 + DB 중복 확인
      * <p>
-     * 발급하는 쿠폰의 수량이 많아질수록 RDB 부하가 커짐 -> Kafka 기술 사용
+     * 1. 사용자별 중복 발급 방지 - Redis Set 기반 제어 (key: applied_user:{couponId})
+     * - 최초 요청만 true, 이후는 중복으로 간주
+     * - 중복이면 발급 수량 증가를 수행하지 않음 (정확한 수량 보장 목적)
+     * <p>
+     * 2. 전체 발급 수량 제한 - Redis INCR 기반 제어 (key: coupon_count:{couponId})
+     * - 최초 요청인 경우에만 수량 증가
+     * - 초과 시 Redis 값 롤백 (decrement)
+     * <p>
+     * 3. Kafka 기반 비동기 처리
+     * - 발급은 Redis 기준으로 선검증 → Kafka 메시지 전송 → Consumer가 DB 저장
+     * - RDB 부하는 줄이고, 발급 속도는 향상됨
+     * <p>
+     * 캐시된 쿠폰 정보를 사용해 RDB 조회 부하도 최소화함
      */
     @Transactional(readOnly = true)
     public CouponIssueResult issue(final CouponIssueCommand command) {
@@ -75,33 +102,51 @@ public class CouponService {
 
         try {
 
-            final Coupon coupon = couponRepository.findById(couponId)
-                    .orElseThrow(() -> new CouponNotFoundException("존재하지 않는 쿠폰입니다."));
+            final Coupon coupon = couponCacheRepository.findById(couponId)
+                    .orElseGet(() -> {
+                        Coupon fromDb = couponRepository.findById(couponId)
+                                .orElseThrow(() -> new CouponNotFoundException("존재하지 않는 쿠폰입니다."));
+                        couponCacheRepository.save(fromDb);
+                        return fromDb;
+                    });
 
             coupon.updateStatusBasedOnDate(LocalDateTime.now());
             if (coupon.getCouponStatus() != CouponStatus.ACTIVE) {
                 throw new InvalidCouponException("현재 쿠폰은 발급 가능한 상태가 아닙니다.");
             }
 
-            if (issuedCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+//            if (issuedCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+//                throw new InvalidIssuedCouponException("이미 해당 쿠폰을 발급받았습니다.");
+//            }
+            // Redis 기반 사용자 중복 발급 방지 (최초 요청만 true 반환)
+            boolean isFirstIssue = appliedUserRepository.add(couponId, userId);
+            if (!isFirstIssue) {
                 throw new InvalidIssuedCouponException("이미 해당 쿠폰을 발급받았습니다.");
             }
 
-            // int issuedCount = issuedCouponRepository.countByCouponId(couponId);
+            //int issuedCount = issuedCouponRepository.countByCouponId(couponId);
             // 기존 DB 기반 발급 수량 계산 대신
             // Redis 기반 발급 수량 제어 (key: coupon_count:{couponId})
             String countKey = "coupon_count:" + couponId;
             Long issuedCount = couponCountRedisRepository.increment(countKey);
             if (issuedCount > coupon.getTotalQuantity()) {
+                couponCountRedisRepository.decrement(countKey);
+                appliedUserRepository.remove(couponId, userId);
                 throw new InvalidIssuedCouponException("해당 쿠폰의 발급 수량이 초과되었습니다.");
             }
 
-            // [이전 동기 방식] Kafka 도입 전에는 아래 로직으로 발급 즉시 DB에 저장했습니다.
+            // [이전 - 동기식 처리] Kafka 도입 전에는 아래 로직으로 발급 즉시 DB에 저장했습니다.
 //            final IssuedCoupon issuedCoupon = new IssuedCoupon(userId, couponId);
 //            issuedCouponRepository.save(issuedCoupon);
 //            return CouponIssueResult.from(issuedCoupon);
+            // [현재 - 비동기 처리]
             couponIssueProducer.issue(userId, couponId);
-            return new CouponIssueResult(userId, couponId, false, LocalDateTime.now());
+            return CouponIssueResult.success(userId, couponId);
+
+        } catch (Exception e) {
+            log.error("failed to issue coupon - userId: {}, couponId: {}", userId, couponId, e);
+            failedIssuedCouponRepository.save(new FailedIssuedCoupon(userId, couponId));
+            return CouponIssueResult.failure(userId, couponId);
 
         } finally {
             couponCountRedisRepository.releaseLock(lockKey);

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/CouponService.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/CouponService.java
@@ -1,6 +1,5 @@
 package dev.be.coupon.api.coupon.application;
 
-import deb.be.coupon.CouponStatus;
 import dev.be.coupon.api.coupon.application.dto.CouponCreateCommand;
 import dev.be.coupon.api.coupon.application.dto.CouponCreateResult;
 import dev.be.coupon.api.coupon.application.dto.CouponIssueCommand;
@@ -13,7 +12,6 @@ import dev.be.coupon.api.coupon.domain.FailedIssuedCoupon;
 import dev.be.coupon.api.coupon.domain.FailedIssuedCouponRepository;
 import dev.be.coupon.api.coupon.domain.IssuedCouponRepository;
 import dev.be.coupon.api.coupon.domain.UserRoleChecker;
-import dev.be.coupon.api.coupon.domain.exception.InvalidCouponException;
 import dev.be.coupon.api.coupon.domain.exception.UnauthorizedAccessException;
 import dev.be.coupon.api.coupon.infrastructure.kafka.producer.CouponIssueProducer;
 import dev.be.coupon.api.coupon.infrastructure.redis.AppliedUserRepository;
@@ -110,10 +108,7 @@ public class CouponService {
                         return fromDb;
                     });
 
-            coupon.updateStatusBasedOnDate(LocalDateTime.now());
-            if (coupon.getCouponStatus() != CouponStatus.ACTIVE) {
-                throw new InvalidCouponException("현재 쿠폰은 발급 가능한 상태가 아닙니다.");
-            }
+            coupon.validateIssuable(LocalDateTime.now());
 
 //            if (issuedCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
 //                throw new InvalidIssuedCouponException("이미 해당 쿠폰을 발급받았습니다.");

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/dto/CouponIssueResult.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/dto/CouponIssueResult.java
@@ -11,6 +11,8 @@ public record CouponIssueResult(
         boolean used,
         LocalDateTime issuedAt
 ) {
+
+    // 동기 저장 시 사용
     public static CouponIssueResult from(final IssuedCoupon issuedCoupon) {
         return new CouponIssueResult(
                 issuedCoupon.getUserId(),
@@ -18,5 +20,13 @@ public record CouponIssueResult(
                 issuedCoupon.isUsed(),
                 issuedCoupon.getIssuedAt()
         );
+    }
+
+    public static CouponIssueResult success(final UUID userId, final UUID couponId) {
+        return new CouponIssueResult(userId, couponId, false, LocalDateTime.now());
+    }
+
+    public static CouponIssueResult failure(final UUID userId, final UUID couponId) {
+        return new CouponIssueResult(userId, couponId, false, LocalDateTime.now());
     }
 }

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/dto/CouponIssueResult.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/dto/CouponIssueResult.java
@@ -9,6 +9,8 @@ public record CouponIssueResult(
         UUID userId,
         UUID couponId,
         boolean used,
+        boolean alreadyIssued,
+        boolean quantityExceeded,
         LocalDateTime issuedAt
 ) {
 
@@ -18,15 +20,25 @@ public record CouponIssueResult(
                 issuedCoupon.getUserId(),
                 issuedCoupon.getCouponId(),
                 issuedCoupon.isUsed(),
+                false,
+                false,
                 issuedCoupon.getIssuedAt()
         );
     }
 
     public static CouponIssueResult success(final UUID userId, final UUID couponId) {
-        return new CouponIssueResult(userId, couponId, false, LocalDateTime.now());
+        return new CouponIssueResult(userId, couponId, false, false, false, LocalDateTime.now());
+    }
+
+    public static CouponIssueResult alreadyIssued(final UUID userId, final UUID couponId) {
+        return new CouponIssueResult(userId, couponId, false, true, false, LocalDateTime.now());
+    }
+
+    public static CouponIssueResult quantityExceeded(final UUID userId, final UUID couponId) {
+        return new CouponIssueResult(userId, couponId, false, false, true, LocalDateTime.now());
     }
 
     public static CouponIssueResult failure(final UUID userId, final UUID couponId) {
-        return new CouponIssueResult(userId, couponId, false, LocalDateTime.now());
+        return new CouponIssueResult(userId, couponId, false, false, false, LocalDateTime.now());
     }
 }

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/domain/Coupon.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/domain/Coupon.java
@@ -125,6 +125,13 @@ public class Coupon {
         }
     }
 
+    public void validateIssuable(final LocalDateTime now) {
+        updateStatusBasedOnDate(now);
+        if (this.couponStatus != CouponStatus.ACTIVE) {
+            throw new InvalidCouponException("현재 쿠폰은 발급 가능한 상태가 아닙니다.");
+        }
+    }
+
     /**
      * 현재 시점을 기준으로 쿠폰 상태를 갱신합니다.
      * <p>
@@ -135,7 +142,7 @@ public class Coupon {
      * - 매일 자정 등 주기적으로 실행되는 스케줄러에서 전체 쿠폰 상태 일괄 갱신
      * - 또는 쿠폰 조회/발급 시점에 동적으로 상태 갱신
      */
-    public void updateStatusBasedOnDate(final LocalDateTime now) {
+    private void updateStatusBasedOnDate(final LocalDateTime now) {
         this.couponStatus = CouponStatus.decideStatus(now, validFrom, validUntil);
     }
 

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/domain/FailedIssuedCoupon.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/domain/FailedIssuedCoupon.java
@@ -1,0 +1,37 @@
+package dev.be.coupon.api.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Table(name = "failed_issued_coupons")
+@Entity
+public class FailedIssuedCoupon {
+
+    @Column(name = "id", columnDefinition = "binary(16)")
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", columnDefinition = "binary(16)", nullable = false)
+    private UUID userId;
+
+    @Column(name = "coupon_id", columnDefinition = "binary(16)", nullable = false)
+    private UUID couponId;
+
+    @Column(name = "failed_at", nullable = false)
+    private LocalDateTime failedAt;
+
+    public FailedIssuedCoupon() {
+    }
+
+    public FailedIssuedCoupon(final UUID userId, final UUID couponId) {
+        this.id = UUID.randomUUID();
+        this.userId = userId;
+        this.couponId = couponId;
+        this.failedAt = LocalDateTime.now();
+    }
+}

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/domain/FailedIssuedCouponRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/domain/FailedIssuedCouponRepository.java
@@ -1,0 +1,6 @@
+package dev.be.coupon.api.coupon.domain;
+
+public interface FailedIssuedCouponRepository {
+
+    FailedIssuedCoupon save(final FailedIssuedCoupon failedIssuedCoupon);
+}

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/jpa/CouponJpaRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/jpa/CouponJpaRepository.java
@@ -1,4 +1,4 @@
-package dev.be.coupon.api.coupon.infrastructure;
+package dev.be.coupon.api.coupon.infrastructure.jpa;
 
 import dev.be.coupon.api.coupon.domain.Coupon;
 import dev.be.coupon.api.coupon.domain.CouponRepository;

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/jpa/FailedIssuedCouponJpaRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/jpa/FailedIssuedCouponJpaRepository.java
@@ -1,0 +1,13 @@
+package dev.be.coupon.api.coupon.infrastructure.jpa;
+
+import dev.be.coupon.api.coupon.domain.FailedIssuedCoupon;
+import dev.be.coupon.api.coupon.domain.FailedIssuedCouponRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface FailedIssuedCouponJpaRepository extends FailedIssuedCouponRepository, JpaRepository<FailedIssuedCoupon, UUID> {
+
+    @Override
+    FailedIssuedCoupon save(final FailedIssuedCoupon failedIssuedCoupon);
+}

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/jpa/IssuedCouponJpaRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/jpa/IssuedCouponJpaRepository.java
@@ -1,4 +1,4 @@
-package dev.be.coupon.api.coupon.infrastructure;
+package dev.be.coupon.api.coupon.infrastructure.jpa;
 
 import dev.be.coupon.api.coupon.domain.IssuedCoupon;
 import dev.be.coupon.api.coupon.domain.IssuedCouponRepository;

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/AppliedUserRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/AppliedUserRepository.java
@@ -1,0 +1,33 @@
+package dev.be.coupon.api.coupon.infrastructure.redis;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public class AppliedUserRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String KEY_PREFIX = "applied_user:";
+
+    public AppliedUserRepository(final RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * @return true = 최초 발급 요청 (Redis에 성공적으로 추가됨), false = 이미 발급 요청 이력 있음
+     */
+    public boolean add(final UUID couponId, final UUID userId) {
+        String key = KEY_PREFIX + couponId;
+        Long result = redisTemplate
+                .opsForSet()
+                .add(key, userId.toString());
+        return result != null && result > 0;
+    }
+
+    public void remove(final UUID couponId, final UUID userId) {
+        String key = KEY_PREFIX + couponId;
+        redisTemplate.opsForSet().remove(key, userId.toString());
+    }
+}

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCacheRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCacheRepository.java
@@ -1,0 +1,32 @@
+package dev.be.coupon.api.coupon.infrastructure.redis;
+
+import dev.be.coupon.api.coupon.domain.Coupon;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class CouponCacheRepository {
+
+    private final RedisTemplate<String, Coupon> redisTemplate;
+    private static final String COUPON_KEY_PREFIX = "coupon:";
+
+    public CouponCacheRepository(RedisTemplate<String, Coupon> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Optional<Coupon> findById(final UUID couponId) {
+        String key = COUPON_KEY_PREFIX + couponId;
+        Coupon cached = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(cached);
+    }
+
+    public void save(Coupon coupon) {
+        String key = COUPON_KEY_PREFIX + coupon.getId();
+        // 해당 쿠폰 캐시의 TTL(Time-To-Live) 값
+        redisTemplate.opsForValue().set(key, coupon, Duration.ofMinutes(10));
+    }
+}

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepository.java
@@ -1,4 +1,4 @@
-package dev.be.coupon.api.coupon.infrastructure;
+package dev.be.coupon.api.coupon.infrastructure.redis;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepository.java
@@ -17,13 +17,13 @@ public class CouponCountRedisRepository {
     public Long increment(final String key) {
         return redisTemplate
                 .opsForValue()
-                .increment(key);
+                .increment(key); // INCR
     }
 
     public Long decrement(final String key) {
         return redisTemplate
                 .opsForValue()
-                .decrement(key);
+                .decrement(key); // DECR
     }
 
     public boolean tryLock(final String lockKey, final long timeoutSeconds) {

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepository.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepository.java
@@ -20,6 +20,12 @@ public class CouponCountRedisRepository {
                 .increment(key);
     }
 
+    public Long decrement(final String key) {
+        return redisTemplate
+                .opsForValue()
+                .decrement(key);
+    }
+
     public boolean tryLock(final String lockKey, final long timeoutSeconds) {
         return Boolean.TRUE.equals(redisTemplate
                 .opsForValue()

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/config/RedisConfig.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/redis/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package dev.be.coupon.api.coupon.infrastructure.redis.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.be.coupon.api.coupon.domain.Coupon;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Coupon> couponRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Coupon> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // LocalDateTime 대응
+        mapper.activateDefaultTyping(mapper.getPolymorphicTypeValidator(), ObjectMapper.DefaultTyping.NON_FINAL);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceTest.java
@@ -238,10 +238,6 @@ class CouponServiceTest {
         final Long userSetSize = redisTemplate.opsForSet().size(appliedKey);
         assertThat(userSetSize).isEqualTo(1); // Redis 기반 중복 방지 확인
 
-        final String countKey = "coupon_count:" + couponId;
-        final String count = redisTemplate.opsForValue().get(countKey);
-        assertThat(count).isEqualTo("1"); // 발급 수량도 1건
-
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isEqualTo(1);
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isLessThanOrEqualTo(1);
         System.out.println("최종 쿠폰 발급 수: " + issuedCouponRepository.countByCouponId(couponId));
@@ -269,9 +265,6 @@ class CouponServiceTest {
         Thread.sleep(10000);
 
         // then
-        final String appliedKey = "applied_user:" + couponId;
-        final Long userSetSize = redisTemplate.opsForSet().size(appliedKey);
-        assertThat(userSetSize).isEqualTo(500);
 
         final String countKey = "coupon_count:" + couponId;
         final String count = redisTemplate.opsForValue().get(countKey);
@@ -312,9 +305,6 @@ class CouponServiceTest {
         Thread.sleep(10000);
 
         // then
-        final String appliedKey = "applied_user:" + couponId;
-        final Long userSetSize = redisTemplate.opsForSet().size(appliedKey);
-        assertThat(userSetSize).isEqualTo(500);
 
         final String countKey = "coupon_count:" + couponId;
         final String count = redisTemplate.opsForValue().get(countKey);

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceTest.java
@@ -6,12 +6,16 @@ import dev.be.coupon.api.coupon.application.dto.CouponIssueCommand;
 import dev.be.coupon.api.coupon.application.dto.CouponIssueResult;
 import dev.be.coupon.api.coupon.application.exception.InvalidIssuedCouponException;
 import dev.be.coupon.api.coupon.domain.CouponRepository;
+import dev.be.coupon.api.coupon.domain.FailedIssuedCouponRepository;
 import dev.be.coupon.api.coupon.domain.FakeUserRoleChecker;
+import dev.be.coupon.api.coupon.domain.IssuedCouponRepository;
 import dev.be.coupon.api.coupon.domain.exception.InvalidCouponTypeException;
 import dev.be.coupon.api.coupon.domain.exception.UnauthorizedAccessException;
-import dev.be.coupon.api.coupon.infrastructure.CouponCountRedisRepository;
 import dev.be.coupon.api.coupon.infrastructure.kafka.dto.CouponIssueMessage;
 import dev.be.coupon.api.coupon.infrastructure.kafka.producer.CouponIssueProducer;
+import dev.be.coupon.api.coupon.infrastructure.redis.AppliedUserRepository;
+import dev.be.coupon.api.coupon.infrastructure.redis.CouponCacheRepository;
+import dev.be.coupon.api.coupon.infrastructure.redis.CouponCountRedisRepository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.AfterEach;
@@ -26,17 +30,43 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+/**
+ * CouponServiceTest 주의사항:
+ * <p>
+ * 이 테스트는 Kafka Consumer 가 실제 DB(JPA Repository)에 접근해 데이터를 저장하는 구조이므로,
+ * 테스트에서도 Spring Context 에서 관리하는 실제 JPA 기반 Repository 를 사용해야 합니다.
+ * <p>
+ * 특히, InMemoryCouponRepository 또는 InMemoryIssuedCouponRepository 를 직접 생성해 사용할 경우,
+ * Kafka Consumer 가 접근하는 Repository 와 분리되어 테스트 결과가 어긋나게 됩니다.
+ * <p>
+ * 따라서 아래 Repository 들은 모두 @Autowired 로 주입 받아야 합니다:
+ * - CouponRepository
+ * - IssuedCouponRepository
+ */
 @SpringBootTest
 class CouponServiceTest {
 
     private CouponService couponService;
     private FakeUserRoleChecker userRoleChecker;
-    private InMemoryIssuedCouponRepository issuedCouponRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponCacheRepository couponCacheRepository;
+
+    @Autowired
+    private IssuedCouponRepository issuedCouponRepository;
+
+    @Autowired
+    private FailedIssuedCouponRepository failedIssuedCouponRepository;
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
@@ -44,38 +74,50 @@ class CouponServiceTest {
     @Autowired
     private KafkaTemplate<String, CouponIssueMessage> kafkaTemplate;
 
+    @Autowired
+    private AppliedUserRepository appliedUserRepository;
+
     @BeforeEach
     void setUp() {
-        CouponRepository couponRepository = new InMemoryCouponRepository();
-        issuedCouponRepository = new InMemoryIssuedCouponRepository();
         userRoleChecker = new FakeUserRoleChecker();
-        userRoleChecker.updateIsAdmin(true);
-        CouponCountRedisRepository couponCountRedisRepository = new CouponCountRedisRepository(redisTemplate);
+        userRoleChecker.updateIsAdmin(true); // 기본값으로 관리자 권한을 부여함
 
-        // 실제 KafkaProducer 사용
+        CouponCountRedisRepository couponCountRedisRepository = new CouponCountRedisRepository(redisTemplate);
         CouponIssueProducer couponIssueProducer = new CouponIssueProducer(kafkaTemplate);
 
         couponService = new CouponService(
                 couponRepository,
-                userRoleChecker,
-                issuedCouponRepository,
+                couponCacheRepository,
                 couponCountRedisRepository,
-                couponIssueProducer
+                couponIssueProducer,
+                issuedCouponRepository,
+                appliedUserRepository,
+                failedIssuedCouponRepository,
+                userRoleChecker
         );
     }
 
     @AfterEach
     void tearDown() {
-        redisTemplate.keys("coupon_count:*").forEach(redisTemplate::delete);
-        redisTemplate.keys("lock:coupon:*").forEach(redisTemplate::delete);
+        safeDelete("coupon_count:*");
+        safeDelete("lock:coupon:*");
+        safeDelete("applied_user:*");
+        safeDelete("coupon:*");
     }
 
-    @DisplayName("쿠폰을 생성한다.")
+    private void safeDelete(final String pattern) {
+        Optional.ofNullable(redisTemplate.keys(pattern))
+                .ifPresent(keys -> keys.stream()
+                        .filter(Objects::nonNull)
+                        .forEach(redisTemplate::delete));
+    }
+
+    @DisplayName("관리자가 쿠폰을 생성한다.")
     @Test
     void success_coupon() {
         // given
-        final UUID userID = UUID.randomUUID();
-        final CouponCreateCommand expected = new CouponCreateCommand(userID, "치킨", "CHICKEN", 1, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+        final UUID adminId = UUID.randomUUID();
+        final CouponCreateCommand expected = new CouponCreateCommand(adminId, "치킨", "CHICKEN", 1, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
 
         // when
         final CouponCreateResult actual = couponService.create(expected);
@@ -90,8 +132,8 @@ class CouponServiceTest {
     @ValueSource(strings = {"KHICKEN", "BIZZA", "VURGER"})
     void should_throw_exception_when_coupon_type_is_invalid(final String type) {
         // given
-        final UUID userID = UUID.randomUUID();
-        final CouponCreateCommand expected = new CouponCreateCommand(userID, "치킨", type, 1, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+        final UUID adminId = UUID.randomUUID();
+        final CouponCreateCommand expected = new CouponCreateCommand(adminId, "치킨", type, 1, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
 
         // when & then
         assertThatThrownBy(() -> couponService.create(expected)).isInstanceOf(InvalidCouponTypeException.class).hasMessage("쿠폰 타입이 지정되지 않았습니다.");
@@ -101,8 +143,8 @@ class CouponServiceTest {
     @Test
     void should_throw_exception_when_user_is_not_admin() {
         // given
-        final UUID userID = UUID.randomUUID();
-        final CouponCreateCommand expected = new CouponCreateCommand(userID, "치킨", "CHICKEN", 1, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+        final UUID adminId = UUID.randomUUID();
+        final CouponCreateCommand expected = new CouponCreateCommand(adminId, "치킨", "CHICKEN", 1, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
         userRoleChecker.updateIsAdmin(false); // 관리자 권한이 아닌 경우: false
 
         // when & then
@@ -133,7 +175,7 @@ class CouponServiceTest {
 
     @DisplayName("동일한 사용자에게 쿠폰을 1000번 발급 요청해도 중복 발급은 1회만 된다. - 단일 스레드")
     @Test
-    void should_only_issue_once_for_same_user() {
+    void should_only_issue_once_for_same_user() throws InterruptedException {
         // given
         final UUID userId = UUID.randomUUID();
         final CouponCreateCommand command = new CouponCreateCommand(userId, "햄버거 쿠폰", "BURGER", 1000, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
@@ -149,8 +191,16 @@ class CouponServiceTest {
             }
         }
 
+        Thread.sleep(10000);
+
         // then
+        // Redis 중복 발급 방지 키 확인
+        final String key = "applied_user:" + couponId;
+        final Long size = redisTemplate.opsForSet().size(key);
+        assertThat(size).isEqualTo(1);
+
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isEqualTo(1);
+        System.out.println("최종 쿠폰 발급 수: " + issuedCouponRepository.countByCouponId(couponId));
     }
 
     @DisplayName("동일한 사용자에게 쿠폰을 1,000,000번 동시 발급 요청해도 중복 발급은 1회만 된다. - 멀티 스레드")
@@ -181,7 +231,17 @@ class CouponServiceTest {
         latch.await();
         executor.shutdown();
 
+        Thread.sleep(10000);
+
         // then
+        final String appliedKey = "applied_user:" + couponId;
+        final Long userSetSize = redisTemplate.opsForSet().size(appliedKey);
+        assertThat(userSetSize).isEqualTo(1); // Redis 기반 중복 방지 확인
+
+        final String countKey = "coupon_count:" + couponId;
+        final String count = redisTemplate.opsForValue().get(countKey);
+        assertThat(count).isEqualTo("1"); // 발급 수량도 1건
+
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isEqualTo(1);
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isLessThanOrEqualTo(1);
         System.out.println("최종 쿠폰 발급 수: " + issuedCouponRepository.countByCouponId(couponId));
@@ -189,7 +249,7 @@ class CouponServiceTest {
 
     @DisplayName("1,000명의 사용자에게 수량 500개짜리 쿠폰을 발급하면 최대 500개만 발급된다. - 단일 스레드")
     @Test
-    void should_only_issue_up_to_total_quantity_limit() {
+    void should_only_issue_up_to_total_quantity_limit() throws InterruptedException {
         // given
         final UUID adminId = UUID.randomUUID();
         final CouponCreateCommand command = new CouponCreateCommand(adminId, "피자 쿠폰", "PIZZA", 500, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
@@ -206,11 +266,22 @@ class CouponServiceTest {
             }
         }
 
+        Thread.sleep(10000);
+
         // then
+        final String appliedKey = "applied_user:" + couponId;
+        final Long userSetSize = redisTemplate.opsForSet().size(appliedKey);
+        assertThat(userSetSize).isEqualTo(500);
+
+        final String countKey = "coupon_count:" + couponId;
+        final String count = redisTemplate.opsForValue().get(countKey);
+        assertThat(count).isEqualTo("500");
+
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isEqualTo(500);
+        System.out.println("최종 쿠폰 발급 수: " + issuedCouponRepository.countByCouponId(couponId));
     }
 
-    @DisplayName("1,000,000명의 사용자에게 동시 발급 요청 시 수량 500개 초과 발급되지 않는다. - 멀티 스레드")
+    @DisplayName("1,000,000명의 사용자에게 동시 발급 요청 시 수량 500개가 초과 발급되지 않는다. - 멀티 스레드")
     @Test
     void should_only_issue_up_to_total_quantity_limit_multithreaded() throws InterruptedException {
         // given
@@ -238,29 +309,66 @@ class CouponServiceTest {
         latch.await();
         executor.shutdown();
 
+        Thread.sleep(10000);
+
         // then
+        final String appliedKey = "applied_user:" + couponId;
+        final Long userSetSize = redisTemplate.opsForSet().size(appliedKey);
+        assertThat(userSetSize).isEqualTo(500);
+
+        final String countKey = "coupon_count:" + couponId;
+        final String count = redisTemplate.opsForValue().get(countKey);
+        assertThat(count).isEqualTo("500");
+
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isEqualTo(500);
         assertThat(issuedCouponRepository.countByCouponId(couponId)).isLessThanOrEqualTo(500);
         System.out.println("최종 쿠폰 발급 수: " + issuedCouponRepository.countByCouponId(couponId));
+    }
+
+    @DisplayName("쿠폰 수량 초과 시 쿠폰 발급 수량이 롤백된다.")
+    @Test
+    void should_decrement_count_when_quantity_exceeded() throws InterruptedException {
+        // given
+        final UUID adminId = UUID.randomUUID();
+        final CouponCreateCommand command = new CouponCreateCommand(adminId, "수량 1 쿠폰", "CHICKEN", 1, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+        final UUID couponId = couponService.create(command).id();
+
+        final UUID user1 = UUID.randomUUID();
+        final UUID user2 = UUID.randomUUID();
+
+        // when
+        couponService.issue(new CouponIssueCommand(user1, couponId));
+        try {
+            couponService.issue(new CouponIssueCommand(user2, couponId));
+        } catch (InvalidIssuedCouponException ignore) {
+        }
+
+        Thread.sleep(5000);
+
+        // then
+        final String countKey = "coupon_count:" + couponId;
+        final Long count = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get(countKey)));
+        assertThat(count).isEqualTo(1); // 롤백이 되지 않으면 2가 됨
+        assertThat(issuedCouponRepository.countByCouponId(couponId)).isEqualTo(1);
     }
 
     @DisplayName("Kafka 메시지가 전송된다.")
     @Test
     void should_send_kafka_message_on_issue() {
         // given
-        final UUID userId = UUID.randomUUID();
+        final UUID adminId = UUID.randomUUID();
         final CouponCreateCommand createCommand = new CouponCreateCommand(
-                userId, "치킨", "CHICKEN", 10, LocalDateTime.now(), LocalDateTime.now().plusDays(1)
+                adminId, "치킨", "CHICKEN", 10, LocalDateTime.now(), LocalDateTime.now().plusDays(1)
         );
         final UUID couponId = couponService.create(createCommand).id();
 
-        final CouponIssueCommand issueCommand = new CouponIssueCommand(userId, couponId);
+        final CouponIssueCommand issueCommand = new CouponIssueCommand(adminId, couponId);
 
         // when
         final CouponIssueResult result = couponService.issue(issueCommand);
 
         // then
-        assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.userId()).isEqualTo(adminId);
         assertThat(result.couponId()).isEqualTo(couponId);
         System.out.println("Kafka 메시지 전송 완료 (터미널에서 확인)");
     }
@@ -282,9 +390,9 @@ class CouponServiceTest {
                 final CouponIssueResult result = couponService.issue(new CouponIssueCommand(userId, couponId));
                 assertThat(result.userId()).isEqualTo(userId);
                 assertThat(result.couponId()).isEqualTo(couponId);
-            } catch (InvalidIssuedCouponException ignore) {
+            } catch (InvalidIssuedCouponException e) {
                 // 수량 초과가 발생하지 않도록 생성 수량을 100으로 지정했기 때문에 무시 X
-                throw new AssertionError("예상치 못한 발급 실패 발생: " + ignore.getMessage());
+                throw new AssertionError("예상치 못한 발급 실패 발생: " + e.getMessage());
             }
         }
 
@@ -293,6 +401,6 @@ class CouponServiceTest {
         String countValue = redisTemplate.opsForValue().get(redisKey);
         assertThat(countValue).isEqualTo("100");
 
-        System.out.println("✔ Kafka 메시지 100건 발송 및 Redis 발급 수량 확인 완료");
+        System.out.println("Kafka 메시지 100건 발송 및 Redis 발급 수량 확인 완료");
     }
 }

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/domain/CouponTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/domain/CouponTest.java
@@ -99,7 +99,7 @@ class CouponTest {
         Coupon coupon = new Coupon("쿠폰", CouponType.PIZZA, 10, now.minusDays(1), now.plusDays(1));
 
         // when
-        coupon.updateStatusBasedOnDate(now);
+        coupon.validateIssuable(now);
 
         // then
         assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.ACTIVE);

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepositoryTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/infrastructure/redis/CouponCountRedisRepositoryTest.java
@@ -1,4 +1,4 @@
-package dev.be.coupon.api.coupon.infrastructure;
+package dev.be.coupon.api.coupon.infrastructure.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;

--- a/coupon/coupon-kafka-consumer/build.gradle
+++ b/coupon/coupon-kafka-consumer/build.gradle
@@ -8,7 +8,13 @@ dependencies {
 	// spring
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// kafka
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	// jackson
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
 
 	// db - mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/CouponIssueConsumer.java
+++ b/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/CouponIssueConsumer.java
@@ -2,7 +2,7 @@ package dev.be.coupon.kafka.consumer;
 
 import dev.be.coupon.kafka.consumer.domain.IssuedCoupon;
 import dev.be.coupon.kafka.consumer.domain.IssuedCouponRepository;
-import dev.be.coupon.kafka.dto.CouponIssueMessage;
+import dev.be.coupon.kafka.consumer.dto.CouponIssueMessage;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/config/KafkaConsumerConfig.java
+++ b/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/config/KafkaConsumerConfig.java
@@ -1,6 +1,6 @@
 package dev.be.coupon.kafka.consumer.config;
 
-import dev.be.coupon.kafka.dto.CouponIssueMessage;
+import dev.be.coupon.kafka.consumer.dto.CouponIssueMessage;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.context.annotation.Bean;

--- a/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/dto/CouponIssueMessage.java
+++ b/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/dto/CouponIssueMessage.java
@@ -1,4 +1,4 @@
-package dev.be.coupon.kafka.dto;
+package dev.be.coupon.kafka.consumer.dto;
 
 import java.util.UUID;
 


### PR DESCRIPTION
### Checklist
- [x] 💯 Have you passed all tests?
- [x] ✅ Does the project build successfully?
- [x] 🧹 Have you removed unnecessary code?
- [x] 💭 Is the related issue registered?
- [x] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`

## Description

- [x] move JPA and Redis components to appropriate packages
- [x] apply user-based Redis Set to prevent duplicate coupon issuance
- [x] replace coupon lookup with Redis and register custom RedisTemplate
- [x] store failed coupon issuance attempts to FailedIssuedCoupon
- [x] refactor(coupon-api): refactor: add Redis decrement support to rollback coupon count on failure
- [x] apply redis to coupon issuance service
- [x] update CouponServiceTest to reflect Redis-based issuance logic
- [x] extract validation methods from coupon issuance
  - replace exception throwing with logging for validation failures


