### PR TITLE
refactor: [coupon-api] [monitoring] update coupon issuance response codes and add prometheus/grafana dashboard

### DIFF
--- a/coupon/coupon-kafka-consumer/src/main/resources/application.yml
+++ b/coupon/coupon-kafka-consumer/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring.application.name: coupon-kafka-consumer
 spring.profiles.active: local
 server.port: 8081
+
+spring:
+  config:
+    import:
+      - logging.yml

--- a/support/monitoring/infra/grafana/dashboards/coupon/coupon-prometheus-dashboard.json
+++ b/support/monitoring/infra/grafana/dashboards/coupon/coupon-prometheus-dashboard.json
@@ -1,0 +1,55 @@
+{
+  "id": null,
+  "uid": "coupon-prometheus",
+  "title": "Coupon Issue - Prometheus Dashboard",
+  "editable": true,
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "5s",
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "graph",
+      "title": "TPS (req/s)",
+      "id": 1,
+      "datasource": "coupon-prometheus",
+      "targets": [
+        {
+          "expr": "rate(http_server_requests_seconds_count{uri=~\"/api/coupon/.*/issue/test\"}[1m])",
+          "refId": "A",
+          "legendFormat": "TPS"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Average Response Time (ms)",
+      "id": 2,
+      "datasource": "coupon-prometheus",
+      "targets": [
+        {
+          "expr": "(rate(http_server_requests_seconds_sum{uri=~\"/api/coupon/.*/issue/test\"}[1m]) / rate(http_server_requests_seconds_count{uri=~\"/api/coupon/.*/issue/test\"}[1m])) * 1000",
+          "refId": "A",
+          "legendFormat": "Avg Response Time"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "5xx Error Rate (%)",
+      "id": 3,
+      "datasource": "coupon-prometheus",
+      "targets": [
+        {
+          "expr": "100 * rate(http_server_requests_seconds_count{uri=~\"/api/coupon/.*/issue/test\",status=~\"5..\"}[1m]) / rate(http_server_requests_seconds_count{uri=~\"/api/coupon/.*/issue/test\"}[1m])",
+          "refId": "A",
+          "legendFormat": "Error Rate"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Checklist
- [x] 💯 Have you passed all tests?
- [x] ✅ Does the project build successfully?
- [x] 🧹 Have you removed unnecessary code?
- [x] 💭 Is the related issue registered?
- [x] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`

## Description

- [x] refactored coupon issuance response
    - `201 Created`: coupon successfully issued.
    - `200 OK`: coupon already issued for the user (duplicate).
    - `409 Conflict`: coupon issuance limit exceeded.
- [x] add tps, response time, error rate to grafana dashboard

