### PR TITLE
refactor: [coupon-kafka-consumer] coupon issuance failure handling and add monitoring module

### DIFF
--- a/coupon/coupon-kafka-consumer/build.gradle
+++ b/coupon/coupon-kafka-consumer/build.gradle
@@ -4,6 +4,7 @@ jar.enabled = true
 dependencies {
 	implementation project(":coupon:coupon-domain")
 	implementation project(":support:logging")
+	implementation project(":support:monitoring")
 
 	// spring
 	implementation 'org.springframework.boot:spring-boot-starter'

--- a/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/application/CouponIssueFailureRecorder.java
+++ b/coupon/coupon-kafka-consumer/src/main/java/dev/be/coupon/kafka/consumer/application/CouponIssueFailureRecorder.java
@@ -1,0 +1,24 @@
+package dev.be.coupon.kafka.consumer.application;
+
+import dev.be.coupon.domain.coupon.FailedIssuedCoupon;
+import dev.be.coupon.domain.coupon.FailedIssuedCouponRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+// Kafka Consumer에서 쿠폰 발급 실패 이력(FailedIssuedCoupon) 을 저장하는 컴포넌트
+@Component
+public class CouponIssueFailureRecorder {
+    private final FailedIssuedCouponRepository repository;
+
+    public CouponIssueFailureRecorder(FailedIssuedCouponRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void record(UUID userId, UUID couponId) {
+        repository.save(new FailedIssuedCoupon(userId, couponId));
+    }
+}

--- a/coupon/coupon-kafka-consumer/src/main/resources/application.yml
+++ b/coupon/coupon-kafka-consumer/src/main/resources/application.yml
@@ -5,4 +5,29 @@ server.port: 8081
 spring:
   config:
     import:
+      - monitoring.yml
       - logging.yml
+  web.resources.add-mappings: false
+
+server:
+  tomcat:
+    max-connections: 20000
+    threads:
+      max: 600
+      min-spare: 100
+
+---
+spring.config.activate.on-profile: local
+
+
+---
+spring.config.activate.on-profile: dev
+
+
+---
+spring.config.activate.on-profile: staging
+
+
+---
+spring.config.activate.on-profile: live
+

--- a/coupon/coupon-kafka-consumer/src/test/java/dev/be/coupon/kafka/consumer/application/CouponIssueConsumerTest.java
+++ b/coupon/coupon-kafka-consumer/src/test/java/dev/be/coupon/kafka/consumer/application/CouponIssueConsumerTest.java
@@ -1,4 +1,4 @@
-package dev.be.coupon.kafka.consumer;
+package dev.be.coupon.kafka.consumer.application;
 
 import dev.be.coupon.domain.coupon.IssuedCouponRepository;
 import dev.be.coupon.kafka.consumer.dto.CouponIssueMessage;

--- a/coupon/coupon-kafka-consumer/src/test/resources/application.yml
+++ b/coupon/coupon-kafka-consumer/src/test/resources/application.yml
@@ -1,2 +1,31 @@
 spring.application.name: coupon-kafka-consumer
 spring.profiles.active: test
+
+spring:
+  config:
+    import:
+      - monitoring.yml
+      - logging.yml
+  web.resources.add-mappings: false
+
+server:
+  tomcat:
+    max-connections: 20000
+    threads:
+      max: 600
+      min-spare: 100
+
+---
+spring.config.activate.on-profile: local
+
+
+---
+spring.config.activate.on-profile: dev
+
+
+---
+spring.config.activate.on-profile: staging
+
+
+---
+spring.config.activate.on-profile: live


### PR DESCRIPTION
### Checklist
- [x] 💯 Have you passed all tests?
- [x] ✅ Does the project build successfully?
- [x] 🧹 Have you removed unnecessary code?
- [x] 💭 Is the related issue registered?
- [x] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`

## Description

### Problem

- Kafka Consumer(CouponIssueConsumer)에서 쿠폰 발급 DB 저장이 실패하면,
실패 이력(FailedIssuedCoupon) 저장도 **같은 트랜잭션 내에서 롤백되어 실패 기록이 유실**되는 문제가 있었습니다.

- 또한 쿠폰 발급 처리 흐름에 대한 모니터링 지표가 부재하여, 재시도 현황이나 실패 비율을 운영 측면에서 파악하기 어려웠습니다.

### Solution

- 실패 이력 저장 로직을 별도 컴포넌트`CouponIssueFailureRecorder`로 분리하고
`@Transactional(propagation = REQUIRES_NEW)`를 적용하여, 발급 실패 시에도 이력은 안전하게 저장되도록 개선했습니다.

- 또한 Kafka Consumer 모듈에 모니터링 모듈을 추가하여, 추후 Prometheus / Grafana 연동을 통해 발급 성공률, 재시도 건수 등의 지표를 수집할 수 있도록 구조를 준비했습니다.

