### PR TITLE
feat: Implement GlobalTraceId for request tracing (distributed system)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+pinpoint-agent-2.5.4
 
 ### Eclipse ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ vUser 1,000명 동시 요청 환경에서 K6 부하 테스트를 수행한 결�
 #### 6-7. Scheduled Retry (스케줄러 기반 재처리)
 
 * Spring `@Scheduled`가 주기적으로 `FailedIssuedCoupon` 테이블에서 미처리 건을 조회합니다.
-*조회된 건은 다시 Kafka 토픽으로 발행되어 발급을 재시도하고, 성공 시 `isResolved` 플래그를 업데이트합니다.
+* 조회된 건은 다시 Kafka 토픽으로 발행되어 발급을 재시도하고, 성공 시 `isResolved` 플래그를 업데이트합니다.
 
 #### Future Improvement: Move to Dead Letter Queue (최종 실패 처리)
 
@@ -163,7 +163,7 @@ support/
 
 * JPA: 객체지향적인 도메인 모델링과 동적 쿼리 생성을 통해 생산성과 유지보수성을 높였습니다.
 
-* K6 & InfluxDB & Grafana: 실제 트래픽과 유사한 부하 테스트 시나리오를 코드로 작성하고, 성능 지표를 시각적으로 분석하여 병목 지점을 파악하고 개선하기 위해 활용했습니다.
+* K6 & InfluxDB, Prometheus & Grafana: 실제 트래픽과 유사한 부하 테스트 시나리오를 코드로 작성하고, 성능 지표를 시각적으로 분석하여 병목 지점을 파악하고 개선하기 위해 활용했습니다.
 
 
 ---

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/CouponService.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/application/CouponService.java
@@ -114,6 +114,7 @@ public class CouponService {
         try {
             couponIssueProducer.issue(userId, couponId);
             log.info("쿠폰 발급 요청 Kafka 전송 성공 - userId: {}, couponId: {}", userId, couponId);
+            log.info("쿠폰 발급 요청이 성공적으로 접수되었습니다. 잠시 후 '내 쿠폰함'에서 확인해 주세요");
             return CouponIssueResult.success(userId, couponId);
         } catch (KafkaException ke) {
             log.error("Kafka 메시지 발행 실패 - userId: {}, couponId: {}. Redis 변경사항 롤백 시도.", userId, couponId, ke);

--- a/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/kafka/config/KafkaProducerConfig.java
+++ b/coupon/coupon-api/src/main/java/dev/be/coupon/api/coupon/infrastructure/kafka/config/KafkaProducerConfig.java
@@ -1,7 +1,5 @@
 package dev.be.coupon.api.coupon.infrastructure.kafka.config;
 
-import org.springframework.kafka.support.serializer.JsonSerializer;
-import dev.be.coupon.api.coupon.infrastructure.kafka.dto.CouponIssueMessage;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +16,7 @@ import java.util.Map;
 public class KafkaProducerConfig {
 
     @Bean
-    public ProducerFactory<String, CouponIssueMessage> producerFactory() {
+    public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> config = new HashMap<>();
 
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
@@ -29,7 +28,7 @@ public class KafkaProducerConfig {
 
     // 카프카 토픽에 데이터를 전송하기 위해 사용할 Kafka Template을 생성
     @Bean
-    public KafkaTemplate<String, CouponIssueMessage> kafkaTemplate() {
+    public KafkaTemplate<String, Object> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceTest.java
@@ -78,7 +78,7 @@ class CouponServiceTest {
     private RedisTemplate<String, String> redisTemplate;
 
     @Autowired
-    private KafkaTemplate<String, CouponIssueMessage> kafkaTemplate;
+    private KafkaTemplate<String, Object> kafkaTemplate;
 
     @Autowired
     private AppliedUserRepository appliedUserRepository;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ### Application version ###
-applicationVersion=1.0.0
+applicationVersion=1.0.1
 
 ### Project configs ###
 projectGroup=dev.be

--- a/support/logging/src/main/resources/logback/logback-dev.xml
+++ b/support/logging/src/main/resources/logback/logback-dev.xml
@@ -4,7 +4,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{globalTraceId:-}|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/support/logging/src/main/resources/logback/logback-live.xml
+++ b/support/logging/src/main/resources/logback/logback-live.xml
@@ -4,7 +4,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{globalTraceId:-}|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/support/logging/src/main/resources/logback/logback-local.xml
+++ b/support/logging/src/main/resources/logback/logback-local.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{globalTraceId:-}|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/support/logging/src/main/resources/logback/logback-staging.xml
+++ b/support/logging/src/main/resources/logback/logback-staging.xml
@@ -4,7 +4,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{globalTraceId:-}|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/support/logging/src/main/resources/logback/logback-test.xml
+++ b/support/logging/src/main/resources/logback/logback-test.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{globalTraceId:-}|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>


### PR DESCRIPTION
### Checklist
- [x] 💯 Have you passed all tests?
- [x] ✅ Does the project build successfully?
- [x] 🧹 Have you removed unnecessary code?
- [x] 💭 Is the related issue registered?
- [x] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`

## Description

To ensure all logs for a single request flow (including API servers and consumers) share a single, unified GlobalTraceId.

- [x] Integrated the `GlobalTraceId` logic into the existing `HttpRequestAndResponseLoggingFilter.`
- [x] The filter now checks for an `X-Global-Trace-Id` header in incoming requests.
- [x] Both the `globalTraceId` and `traceId` are added to the MDC (Mapped Diagnostic Context) at the start of a request and cleared upon completion.


## Test Result: End-to-End Tracing

This test demonstrates that a single `X-Global-Trace-Id` (`gtxid-coupon-test-001`) initiated from a Postman request is successfully propagated from the `coupon-api` to the `coupon-kafka-consumer`.

> `coupon-api` server (Request handled and message produced)

```bash
// Business logic starts, successfully sends a message to Kafka
01:42:37.011| INFO| gtxid-coupon-test-001|6849b1fc323b33aa496e23dc243b055e,496e23dc243b055e|d.b.c.a.c.application.CouponService|쿠폰 발급 요청 Kafka 전송 성공 - userId: e41dfec8-9e74-4c5a-bc99-9e2893cbeac9, couponId: 8acadbb2-4c2c-4c50-96f9-14de1343f790

// ... (other logs omitted for brevity) ...

// Final HTTP response is logged
01:42:37.019| INFO| gtxid-coupon-test-001|53ed1b0b-f3a6-49db-b065-0fcf2af6,              |.f.v.HttpRequestAndResponseLoggingFilter|
[REQUEST] POST /api/coupon/8acadbb2-4c2c-4c50-96f9-14de1343f790/issue/test [RESPONSE - STATUS: 201 CREATED]
>> RESPONSE_BODY: {"resultType":"SUCCESS","data":{"userId":"e41dfec8-9e74-4c5a-bc99-9e2893cbeac9", ...}, "errorMessage":null}
```

> `coupon-kafka-consumer` server (Message consumed and processed)

```bash
// Consumer receives the message from Kafka, inheriting the GlobalTraceId
01:42:37.451| INFO| gtxid-coupon-test-001|6849b1fd2ea1f8f5a5da88b626406728,a5da88b626406728|d.b.c.k.c.a.CouponIssueConsumer|발급 처리 메시지 수신: CouponIssueMessage[userId=e41dfec8-9e74-4c5a-bc99-9e2893cbeac9, couponId=8acadbb2-4c2c-4c50-96f9-14de1343f790]

// ... (DB queries and other logs omitted) ...

// Business logic in the consumer completes successfully
01:42:37.508| INFO| gtxid-coupon-test-001|6849b1fd2ea1f8f5a5da88b626406728,a5da88b626406728|d.b.c.k.c.a.CouponIssueConsumer|쿠폰 발급 완료: dev.be.coupon.domain.coupon.IssuedCoupon@e24f6017
```