### PR TITLE
feat: Flyway를 통한 DB 마이그레이션 관리 도입

### DIFF
--- a/coupon/coupon-api/build.gradle
+++ b/coupon/coupon-api/build.gradle
@@ -22,6 +22,10 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // flyway
+    implementation ("org.flywaydb:flyway-core:${flywayVersion}")
+    implementation ("org.flywaydb:flyway-mysql:${flywayVersion}")
+
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${swaggerVersion}")
 
     // jwt

--- a/coupon/coupon-api/src/main/resources/application-dev.yml
+++ b/coupon/coupon-api/src/main/resources/application-dev.yml
@@ -3,9 +3,12 @@ spring:
     url: jdbc:mysql://localhost:3306/couponDB
     username: root
     password: 1234
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/coupon/coupon-api/src/main/resources/application-local.yml
+++ b/coupon/coupon-api/src/main/resources/application-local.yml
@@ -3,9 +3,12 @@ spring:
     url: jdbc:mysql://localhost:3306/couponDB
     username: root
     password: 1234
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/coupon/coupon-api/src/main/resources/db/migration/V1__init_project_tables.sql
+++ b/coupon/coupon-api/src/main/resources/db/migration/V1__init_project_tables.sql
@@ -1,0 +1,65 @@
+create table coupons
+(
+    id             binary(16) not null,
+    coupon_type    varchar(255) not null,
+    name           varchar(255) not null,
+    total_quantity integer      not null,
+    coupon_status  varchar(255) not null,
+    valid_from     datetime(6) not null,
+    valid_until    datetime(6) not null,
+    primary key (id)
+) engine = InnoDB;
+
+create table issued_coupons
+(
+    id        binary(16) not null,
+    user_id   binary(16) not null,
+    coupon_id binary(16) not null,
+    used      bit not null,
+    issued_at datetime(6) not null,
+    used_at   datetime(6),
+    primary key (id),
+    unique (user_id, coupon_id)
+) engine = InnoDB;
+
+create table failed_issued_coupons
+(
+    id          binary(16) not null,
+    user_id     binary(16) not null,
+    coupon_id   binary(16) not null,
+    failed_at   datetime(6) not null,
+    retry_count integer not null,
+    is_resolved bit     not null,
+    primary key (id)
+) engine = InnoDB;
+
+create table users
+(
+    id         binary(16) not null,
+    user_role  varchar(255) not null,
+    username   varchar(255) not null,
+    password   varchar(255) not null,
+    created_at datetime(6) not null,
+    updated_at datetime(6) not null,
+    primary key (id)
+) engine = InnoDB;
+
+alter table issued_coupons
+    add constraint fk_issued_coupon_to_coupon
+        foreign key (coupon_id)
+            references coupons (id);
+
+alter table issued_coupons
+    add constraint fk_issued_coupon_to_users
+        foreign key (user_id)
+            references users (id);
+
+alter table failed_issued_coupons
+    add constraint fk_failed_issued_coupon_to_users
+        foreign key (user_id)
+            references users (id);
+
+alter table failed_issued_coupons
+    add constraint fk_failed_issued_coupon_to_coupon
+        foreign key (coupon_id)
+            references coupons (id);

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/CouponApplicationTests.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/CouponApplicationTests.java
@@ -2,8 +2,10 @@ package dev.be.coupon;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CouponApplicationTests {
 
     @Test

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/auth/application/AuthServiceTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/auth/application/AuthServiceTest.java
@@ -15,7 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 class AuthServiceTest {
 
     private UserService userService;

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceImplTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/coupon/application/CouponServiceImplTest.java
@@ -29,6 +29,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -49,6 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * - Docker Compose 실행 - MySQL, Redis, Kafka 구동되어야 함
  * - Kafka Application 실행
  */
+@ActiveProfiles("test")
 @SpringBootTest
 class CouponServiceImplTest {
 

--- a/coupon/coupon-api/src/test/java/dev/be/coupon/api/user/application/UserServiceTest.java
+++ b/coupon/coupon-api/src/test/java/dev/be/coupon/api/user/application/UserServiceTest.java
@@ -11,7 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 class UserServiceTest {
 
     private UserService userService;

--- a/coupon/coupon-api/src/test/resources/application-test.yml
+++ b/coupon/coupon-api/src/test/resources/application-test.yml
@@ -7,7 +7,7 @@ spring:
     enabled: false
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
@@ -16,6 +16,12 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
+    consumer:
+      bootstrap-servers: localhost:9092
 
 springdoc:
   swagger-ui:

--- a/coupon/coupon-api/src/test/resources/application-test.yml
+++ b/coupon/coupon-api/src/test/resources/application-test.yml
@@ -3,6 +3,8 @@ spring:
     url: jdbc:mysql://localhost:3306/couponDB
     username: root
     password: 1234
+  flyway:
+    enabled: false
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/coupon/coupon-consumer/src/main/resources/application-dev.yml
+++ b/coupon/coupon-consumer/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ spring:
     password: 1234
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/coupon/coupon-consumer/src/main/resources/application-local.yml
+++ b/coupon/coupon-consumer/src/main/resources/application-local.yml
@@ -5,7 +5,7 @@ spring:
     password: 1234
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/coupon/coupon-consumer/src/test/java/dev/be/coupon/kafka/consumer/CouponKafkaConsumerApplicationTests.java
+++ b/coupon/coupon-consumer/src/test/java/dev/be/coupon/kafka/consumer/CouponKafkaConsumerApplicationTests.java
@@ -2,7 +2,9 @@ package dev.be.coupon.kafka.consumer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class CouponKafkaConsumerApplicationTests {
 

--- a/coupon/coupon-domain/src/main/java/dev/be/coupon/domain/coupon/Coupon.java
+++ b/coupon/coupon-domain/src/main/java/dev/be/coupon/domain/coupon/Coupon.java
@@ -45,14 +45,14 @@ public class Coupon {
     @Embedded
     private CouponName couponName;
 
-    @Column(name = "type", nullable = false)
+    @Column(name = "coupon_type", nullable = false, columnDefinition = "varchar(255)")
     @Enumerated(EnumType.STRING)
     private CouponType couponType;
 
     @Column(name = "total_quantity", nullable = false)
     private int totalQuantity;
 
-    @Column(name = "status", nullable = false)
+    @Column(name = "coupon_status", nullable = false, columnDefinition = "varchar(255)")
     @Enumerated(EnumType.STRING)
     private CouponStatus couponStatus; // 쿠폰 발급시 기본값으로 사용 가능(ACTIVE) 으로 설정
 

--- a/coupon/coupon-domain/src/main/java/dev/be/coupon/domain/user/User.java
+++ b/coupon/coupon-domain/src/main/java/dev/be/coupon/domain/user/User.java
@@ -28,7 +28,7 @@ public class User {
     @Id
     private UUID id;
 
-    @Column(name = "user_role", nullable = false)
+    @Column(name = "user_role", nullable = false, columnDefinition = "varchar(255)")
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
@@ -39,7 +39,7 @@ public class User {
     private Password password;
 
     @CreatedDate
-    @Column(name = "create_at", nullable = false, updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/coupon/coupon-domain/src/test/java/dev/be/coupon/domain/coupon/CouponTest.java
+++ b/coupon/coupon-domain/src/test/java/dev/be/coupon/domain/coupon/CouponTest.java
@@ -1,8 +1,5 @@
 package dev.be.coupon.domain.coupon;
 
-import dev.be.coupon.domain.coupon.Coupon;
-import dev.be.coupon.domain.coupon.CouponStatus;
-import dev.be.coupon.domain.coupon.CouponType;
 import dev.be.coupon.domain.coupon.exception.CouponNotCurrentlyUsableException;
 import dev.be.coupon.domain.coupon.exception.CouponNotIssuableException;
 import dev.be.coupon.domain.coupon.exception.InvalidCouponException;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   mysql:
     image: mysql:8.0.34
-    container_name: mysql-coupon
+    container_name: mysql
     restart: always
     ports:
       - '3306:3306'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@ springBootVersion=3.2.5
 springDependencyManagementVersion=1.1.6
 springCloudDependenciesVersion=2024.0.0
 
+### Flyway
+flywayVersion=10.15.0
+
 ### Redis
 redissonVersion=3.27.0
 


### PR DESCRIPTION
### Checklist
- [x] 💯 Have you passed all tests?
- [x] ✅ Does the project build successfully?
- [x] 🧹 Have you removed unnecessary code?
- [x] 💭 Is the related issue registered?
- [x] 🔖 Have you added appropriate labels? e.g. `feature`, `refactor`

### Flyway 도입 배경

기존에는 Spring Boot의 `hibernate.ddl-auto` 설정을 사용하여 애플리케이션 시작 시 자동으로 스키마를 생성했습니다. 
이 방식은 초기 개발 단계에서는 편리하지만, 다음과 같은 문제점을 야기합니다.

- **로컬 환경마다 다른 스키마**: 개발자마다 다른 데이터베이스 상태를 가지게 되어 스키마 불일치로 인한 버그가 발생할 수 있습니다.
- **프로덕션 환경 적용의 어려움**: `create` 옵션은 매번 테이블을 삭제하고 재생성하므로 운영 환경에서 사용할 수 없으며, `update` 옵션은 의도치 않은 데이터 손실을 초래할 수 있습니다.
- **변경 이력 관리의 부재**: 스키마 변경 이력이 명확하게 남지 않아, 시간이 지나면서 어떤 변경이 있었는지 파악하기 어렵습니다.

이러한 문제들을 해결하기 위해 Flyway를 도입하여 DB 스키마를 버전별로 관리하고, 모든 환경에서 일관된 스키마를 유지하도록 개선했습니다.

### 주요 변경 사항

Flyway 의존성 추가: build.gradle에 Flyway 의존성을 추가했습니다.

- 초기 스키마 스크립트 작성: `src/main/resources/db/migration/V1__init_schema.sql` 파일을 생성하여 초기 테이블 스키마를 명시했습니다.
- `@Enumerated` 필드 타입 명시: Enum 필드의 DB 컬럼 타입이 TINYINT와 같이 의도치 않은 타입으로 매핑되는 것을 방지하기 위해 columnDefinition = "varchar(255)" 속성을 추가했습니다. 이는 Flyway 스크립트의 `VARCHAR` 타입과 엔티티가 바라보는 스키마를 일치시켜 유효성 검증(ddl-auto: validate)에 성공하도록 합니다.
- Hibernate DDL 비활성화: `application.yml` 에서 ddl-auto 설정을 validate로 변경하여, Flyway가 스키마를 관리하고 Hibernate는 유효성만 검증하도록 역할을 분리했습니다.